### PR TITLE
Fix return handler

### DIFF
--- a/YeetEmulator/OpCodes/Handlers/Ret.cs
+++ b/YeetEmulator/OpCodes/Handlers/Ret.cs
@@ -6,12 +6,7 @@ namespace YeetEmulator.OpCodes.Handlers
 	{
 		public override void ExecuteInstruction(YeetCore core, YeetInstruction instr)
 		{
-			if(core.VMStack.Count == 0)
-				core.VMStack.Push(null);
-
-			object ret = core.VMStack.Pop();
-
-			core.VMStack.Push(ret);
+			core.VMStack.Push(core.VMStack.Count == 0 ? null : core.VMStack.Pop());
 			core.Index++;
 		}
 	}


### PR DESCRIPTION
Before it was pushing a return value from the callee's evaluation stack onto the caller's evaluation stack regardless